### PR TITLE
Implement PostService and add Reaction entity

### DIFF
--- a/src/main/java/com/JKS/community/entity/Member.java
+++ b/src/main/java/com/JKS/community/entity/Member.java
@@ -32,6 +32,9 @@ public class Member {
     @OneToMany(mappedBy = "member")
     private List<Comment> comments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member")
+    private List<Reaction> reaction;
+
     @Builder
     public Member(String loginId, String password, String name) {
         this.loginId = loginId;

--- a/src/main/java/com/JKS/community/entity/Post.java
+++ b/src/main/java/com/JKS/community/entity/Post.java
@@ -61,4 +61,16 @@ public class Post extends BaseTimeEntity {
         this.title = postUpdateDto.getTitle();
         this.content = postUpdateDto.getContent();
     }
+
+    public void increaseViewCount() {
+        this.view_count++;
+    }
+
+    public void increaseLikeCount() {
+        this.like_count++;
+    }
+
+    public void increaseDislikeCount() {
+        this.dislike_count++;
+    }
 }

--- a/src/main/java/com/JKS/community/entity/Post.java
+++ b/src/main/java/com/JKS/community/entity/Post.java
@@ -42,6 +42,9 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post")
     private List<Comment> comments = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post")
+    private List<Reaction> reaction;
+
     @Builder
     public Post(String title, String content, Member member, Category category) {
         this.title = title;

--- a/src/main/java/com/JKS/community/entity/Reaction.java
+++ b/src/main/java/com/JKS/community/entity/Reaction.java
@@ -1,0 +1,22 @@
+package com.JKS.community.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class Reaction {
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    private ReactionType reactionType;
+}

--- a/src/main/java/com/JKS/community/entity/Reaction.java
+++ b/src/main/java/com/JKS/community/entity/Reaction.java
@@ -19,4 +19,22 @@ public class Reaction {
     private Post post;
 
     private ReactionType reactionType;
+
+    public static Reaction of(Member member, Post post, boolean isLike) {
+        Reaction reaction = new Reaction();
+        reaction.member = member;
+        reaction.post = post;
+        reaction.reactionType = isLike ? ReactionType.LIKE : ReactionType.DISLIKE;
+        return reaction;
+    }
+
+
+    public void toggleReaction() {
+        if (this.reactionType == ReactionType.LIKE) {
+            this.reactionType = ReactionType.DISLIKE;
+        } else {
+            this.reactionType = ReactionType.LIKE;
+        }
+    }
+
 }

--- a/src/main/java/com/JKS/community/entity/ReactionType.java
+++ b/src/main/java/com/JKS/community/entity/ReactionType.java
@@ -1,0 +1,6 @@
+package com.JKS.community.entity;
+
+public enum ReactionType {
+    LIKE,
+    DISLIKE;
+}

--- a/src/main/java/com/JKS/community/repository/ReactionRepository.java
+++ b/src/main/java/com/JKS/community/repository/ReactionRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface ReactionRepository extends JpaRepository<Reaction, Long> {
-
-    Optional<Reaction> findByPostIdAndMemberId(Long postId, Long memberId);
+    Optional<Reaction> findByMemberIdAndPostId(Long memberId, Long postId);
 }

--- a/src/main/java/com/JKS/community/repository/ReactionRepository.java
+++ b/src/main/java/com/JKS/community/repository/ReactionRepository.java
@@ -1,0 +1,11 @@
+package com.JKS.community.repository;
+
+import com.JKS.community.entity.Reaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ReactionRepository extends JpaRepository<Reaction, Long> {
+
+    Optional<Reaction> findByPostIdAndMemberId(Long postId, Long memberId);
+}

--- a/src/main/java/com/JKS/community/service/PostService.java
+++ b/src/main/java/com/JKS/community/service/PostService.java
@@ -27,9 +27,6 @@ public interface PostService {
     // 글 검색
     Page<Post> searchPostsByKeyword(String keyword, Pageable pageable);
 
-    // 글 추천 (다시 좋아요를 누르면 취소)
-    void toggleLikePost(Long userId, Long postId);
+    void reactPost(Long memberId, Long postId, boolean isLike);
 
-    // 글 비추천 (다시 싫어요를 누르면 취소)
-    void toggleDislikePost(Long userId, Long postId);
 }

--- a/src/main/java/com/JKS/community/service/PostServiceImpl.java
+++ b/src/main/java/com/JKS/community/service/PostServiceImpl.java
@@ -2,18 +2,18 @@ package com.JKS.community.service;
 
 import com.JKS.community.dto.PostCreateDto;
 import com.JKS.community.dto.PostUpdateDto;
-import com.JKS.community.entity.Category;
-import com.JKS.community.entity.Member;
-import com.JKS.community.entity.Post;
+import com.JKS.community.entity.*;
 import com.JKS.community.repository.CategoryRepository;
 import com.JKS.community.repository.MemberRepository;
 import com.JKS.community.repository.PostRepository;
+import com.JKS.community.repository.ReactionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,17 +22,20 @@ public class PostServiceImpl implements PostService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final ReactionRepository reactionRepository;
 
     @Override
+    // 게시글을 생성하는 메서드
     public Post createPost(PostCreateDto postCreateDto) {
-        // 1. memberId와 categoryId로부터 실제 Member와 Category 엔티티 참조 획득
+        // 1. memberId와 categoryId를 이용하여 Member와 Category 엔티티를 검색
+        // 해당 아이디를 가진 Member 혹은 Category가 없다면 예외 발생
         Member member = memberRepository.findById(postCreateDto.getMemberId())
                 .orElseThrow(() -> new IllegalArgumentException("Invalid memberId:" + postCreateDto.getMemberId()));
 
         Category category = categoryRepository.findById(postCreateDto.getCategoryId())
                 .orElseThrow(() -> new IllegalArgumentException("Invalid categoryId:" + postCreateDto.getCategoryId()));
 
-        // 2. Post 엔티티 생성
+        // 2. 검색한 Member와 Category 엔티티를 이용하여 새로운 Post 엔티티 생성
         Post newPost = Post.builder()
                 .title(postCreateDto.getTitle())
                 .content(postCreateDto.getContent())
@@ -40,51 +43,92 @@ public class PostServiceImpl implements PostService {
                 .category(category)
                 .build();
 
-        // 3. 생성된 엔티티 저장 및 반환
+        // 3. 생성된 Post 엔티티를 저장하고 반환
         return postRepository.save(newPost);
     }
 
     @Override
+    // 게시글을 수정하는 메서드
     public Post updatePost(Long postId, PostUpdateDto updatedPostDto) {
+        // postId로 Post 엔티티를 검색
+        // 해당 아이디를 가진 Post가 없다면 예외 발생
         Post existingPost = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid post Id:" + postId));
 
+        // 검색한 Post 엔티티의 정보를 수정
         existingPost.update(updatedPostDto);
 
+        // 수정된 Post 엔티티를 저장하고 반환
         return postRepository.save(existingPost);
     }
 
     @Override
+    // 게시글을 삭제하는 메서드
     public void deletePost(Long postId) {
+        // postId로 Post 엔티티를 검색
+        // 해당 아이디를 가진 Post가 없다면 예외 발생
         Post existingPost = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid post Id:" + postId));
 
+        // 검색한 Post 엔티티를 삭제
         postRepository.delete(existingPost);
     }
 
     @Override
+    // 게시글을 검색하고 조회수를 증가시키는 메서드
     public Post getPost(Long postId) {
-        return postRepository.findById(postId)
+        // postId로 Post 엔티티를 검색
+        // 해당 아이디를 가진 Post가 없다면 예외 발생
+        Post existingPost = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid post Id:" + postId));
+
+        // 검색한 Post 엔티티의 조회수를 증가시킴
+        existingPost.increaseViewCount();
+
+        // 조회수가 증가된 Post 엔티티를 반환
+        return existingPost;
     }
 
     @Override
+    // 모든 게시글을 페이지에 맞게 검색하는 메서드
     public Page<Post> getPostList(Pageable pageable) {
         return postRepository.findAll(pageable);
     }
 
     @Override
+    // Keyword를 포함하는 게시글을 페이지에 맞게 검색하는 메서드
     public Page<Post> searchPostsByKeyword(String keyword, Pageable pageable) {
         return postRepository.findByTitleContainingOrContentContaining(keyword, keyword, pageable);
     }
 
     @Override
-    public void toggleLikePost(Long userId, Long postId) {
+    // 게시글에 대한 반응을 저장하는 메서드
+    public void reactPost(Long memberId, Long postId, boolean isLike) {
+        // memberId와 postId로 Member와 Post 엔티티를 검색
+        // 해당 아이디를 가진 Member 혹은 Post가 없다면 예외 발생
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("No member found with id " + memberId));
 
-    }
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("No post found with id " + postId));
 
-    @Override
-    public void toggleDislikePost(Long userId, Long postId) {
+        // 해당 Member가 해당 Post에 기존 반응이 있는지 확인
+        Optional<Reaction> optionalReaction = reactionRepository.findByMemberIdAndPostId(memberId, postId);
 
+        // 이미 반응이 있다면 예외 발생
+        if (optionalReaction.isPresent()) {
+            throw new IllegalArgumentException("You've already reacted to this post.");
+        }
+
+        // 새로운 Reaction을 생성하고 저장
+        Reaction newReaction = Reaction.of(member, post, isLike);
+        reactionRepository.save(newReaction);
+
+        // 이 Post에 대한 좋아요 혹은 싫어요 카운트 증가
+        if(isLike){
+            post.increaseLikeCount();
+        }else{
+            post.increaseDislikeCount();
+        }
     }
 }


### PR DESCRIPTION
This pull request includes the following changes:

1. `PostService` implementation: Methods for creating, updating, deleting, and retrieving posts have been added in `PostService`. Detailed comments have also been added for each method to explain their functionality.

2. Addition of `ReactionRepository`: A new repository named `ReactionRepository` has been created to manage the reactions on posts.

3. Addition of `Reaction` entity: A new entity named `Reaction` has been added which represents a reaction on a post by a member. The relationships between the `Reaction`, `Member`, and `Post` entities have also been established.

These changes are aimed at improving the functionality of our application by enabling users to react to posts and efficiently managing these reactions.
